### PR TITLE
Remove experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,6 @@
 
 **Description**: Enable full text search of your Cloud Firestore data with Algolia.
 
----
-
-## 🧩 Install this experimental extension
-
-> ⚠️ **Experimental**: This extension is available for testing as an _experimental_ release. It has not been as thoroughly tested as the officially released extensions, and future updates might introduce breaking changes. If you use this extension, please [report bugs and make feature requests](https://github.com/algolia/algolia-firebase-extension/issues/new) in our GitHub repository.
-
 ### Firebase CLI
 
 ```bash


### PR DESCRIPTION
Plan is to go directly to official now so removing the experimental banner