### PR TITLE
fix author and contributor

### DIFF
--- a/extension.yaml
+++ b/extension.yaml
@@ -15,8 +15,13 @@ description: >-
 license: Apache-2.0  # https://spdx.org/licenses/
 
 author:
-  authorName: Sajid Momin
-  url: https://github.com/smomin  # Author URL
+  authorName: Algolia
+  url: https://algolia.com
+
+contributors:
+  - authorName: Sajid Momin
+    email: sajid.momin@algolia.com
+    url: https://github.com/smomin
 
 
 # Public URL for the source code of your extension


### PR DESCRIPTION
The author will be Algolia and the contributor is Sajid. This will fix the legal name showing up on the extension listing page 


![image](https://user-images.githubusercontent.com/678917/114906075-87acba80-9dce-11eb-9e16-04b1f8507414.png)
