### PR TITLE
refactor: add Warsaw cloud function location (europe-central2)

### DIFF
--- a/extension.yaml
+++ b/extension.yaml
@@ -126,6 +126,8 @@ params:
         value: us-west3
       - label: Las Vegas (us-west4)
         value: us-west4
+      - label: Warsaw (europe-central2)
+        value: europe-central2
       - label: Belgium (europe-west1)
         value: europe-west1
       - label: London (europe-west2)

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -11,8 +11,8 @@
         "@algolia/client-common": "^4.8.6",
         "@algolia/transporter": "^4.8.6",
         "algoliasearch": "^4.8.6",
-        "firebase-admin": "^9.5.0",
-        "firebase-functions": "^3.13.2"
+        "firebase-admin": "^9.8.0",
+        "firebase-functions": "^3.14.1"
       },
       "bin": {
         "firestore-algolia-search": "cli.js"
@@ -828,49 +828,59 @@
       }
     },
     "node_modules/@firebase/app-types": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.6.1.tgz",
-      "integrity": "sha512-L/ZnJRAq7F++utfuoTKX4CLBG5YR7tFO3PLzG1/oXXKEezJ0kRL3CMRoueBEmTCzVb/6SIs2Qlaw++uDgi5Xyg=="
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.6.2.tgz",
+      "integrity": "sha512-2VXvq/K+n8XMdM4L2xy5bYp2ZXMawJXluUIDzUBvMthVR+lhxK4pfFiqr1mmDbv9ydXvEAuFsD+6DpcZuJcSSw=="
     },
     "node_modules/@firebase/auth-interop-types": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.1.5.tgz",
-      "integrity": "sha512-88h74TMQ6wXChPA6h9Q3E1Jg6TkTHep2+k63OWg3s0ozyGVMeY+TTOti7PFPzq5RhszQPQOoCi59es4MaRvgCw==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.1.6.tgz",
+      "integrity": "sha512-etIi92fW3CctsmR9e3sYM3Uqnoq861M0Id9mdOPF6PWIg38BXL5k4upCNBggGUpLIS0H1grMOvy/wn1xymwe2g==",
       "peerDependencies": {
         "@firebase/app-types": "0.x",
-        "@firebase/util": "0.x"
+        "@firebase/util": "1.x"
       }
     },
     "node_modules/@firebase/component": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.21.tgz",
-      "integrity": "sha512-kd5sVmCLB95EK81Pj+yDTea8pzN2qo/1yr0ua9yVi6UgMzm6zAeih73iVUkaat96MAHy26yosMufkvd3zC4IKg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.0.tgz",
+      "integrity": "sha512-v18csWtXb0ri+3m7wuGLY/UDgcb89vuMlZGQ//+7jEPLIQeLbylvZhol1uzW9WzoOpxMxOS2W5qyVGX36wZvEA==",
       "dependencies": {
-        "@firebase/util": "0.3.4",
-        "tslib": "^1.11.1"
+        "@firebase/util": "1.1.0",
+        "tslib": "^2.1.0"
       }
     },
+    "node_modules/@firebase/component/node_modules/tslib": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+    },
     "node_modules/@firebase/database": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.8.3.tgz",
-      "integrity": "sha512-i29rr3kcPltIkA8La9M1lgsSxx9bfu5lCQ0T+tbJptZ3UpqpcL1NzCcZa24cJjiLgq3HQNPyLvUvCtcPSFDlRg==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.10.1.tgz",
+      "integrity": "sha512-umT0kynJKc5VpVBOg3+YTDzdJORssh+QqPjoHfbSvtmgZizNiV8mgmKRcDhlVM6CisPb6v5xBn9l8JbK/WRQ1Q==",
       "dependencies": {
-        "@firebase/auth-interop-types": "0.1.5",
-        "@firebase/component": "0.1.21",
-        "@firebase/database-types": "0.6.1",
+        "@firebase/auth-interop-types": "0.1.6",
+        "@firebase/component": "0.5.0",
+        "@firebase/database-types": "0.7.2",
         "@firebase/logger": "0.2.6",
-        "@firebase/util": "0.3.4",
+        "@firebase/util": "1.1.0",
         "faye-websocket": "0.11.3",
-        "tslib": "^1.11.1"
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/@firebase/database-types": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.6.1.tgz",
-      "integrity": "sha512-JtL3FUbWG+bM59iYuphfx9WOu2Mzf0OZNaqWiQ7lJR8wBe7bS9rIm9jlBFtksB7xcya1lZSQPA/GAy2jIlMIkA==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.7.2.tgz",
+      "integrity": "sha512-cdAd/dgwvC0r3oLEDUR+ULs1vBsEvy0b27nlzKhU6LQgm9fCDzgaH9nFGv8x+S9dly4B0egAXkONkVoWcOAisg==",
       "dependencies": {
-        "@firebase/app-types": "0.6.1"
+        "@firebase/app-types": "0.6.2"
       }
+    },
+    "node_modules/@firebase/database/node_modules/tslib": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
     },
     "node_modules/@firebase/logger": {
       "version": "0.2.6",
@@ -878,12 +888,17 @@
       "integrity": "sha512-KIxcUvW/cRGWlzK9Vd2KB864HlUnCfdTH0taHE0sXW5Xl7+W68suaeau1oKNEqmc3l45azkd4NzXTCWZRZdXrw=="
     },
     "node_modules/@firebase/util": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.3.4.tgz",
-      "integrity": "sha512-VwjJUE2Vgr2UMfH63ZtIX9Hd7x+6gayi6RUXaTqEYxSbf/JmehLmAEYSuxS/NckfzAXWeGnKclvnXVibDgpjQQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.1.0.tgz",
+      "integrity": "sha512-lfuSASuPKNdfebuFR8rjFamMQUPH9iiZHcKS755Rkm/5gRT0qC7BMhCh3ZkHf7NVbplzIc/GhmX2jM+igDRCag==",
       "dependencies": {
-        "tslib": "^1.11.1"
+        "tslib": "^2.1.0"
       }
+    },
+    "node_modules/@firebase/util/node_modules/tslib": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
     },
     "node_modules/@google-cloud/common": {
       "version": "3.6.0",
@@ -996,12 +1011,6 @@
       "engines": {
         "node": "^8.13.0 || >=10.10.0"
       }
-    },
-    "node_modules/@grpc/grpc-js/node_modules/@types/node": {
-      "version": "14.14.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
-      "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==",
-      "optional": true
     },
     "node_modules/@grpc/grpc-js/node_modules/google-auth-library": {
       "version": "6.1.6",
@@ -1402,6 +1411,14 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@panva/asn1.js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@panva/asn1.js/-/asn1.js-1.0.0.tgz",
+      "integrity": "sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw==",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -1561,6 +1578,15 @@
         "@types/serve-static": "*"
       }
     },
+    "node_modules/@types/express-jwt": {
+      "version": "0.0.42",
+      "resolved": "https://registry.npmjs.org/@types/express-jwt/-/express-jwt-0.0.42.tgz",
+      "integrity": "sha512-WszgUddvM1t5dPpJ3LhWNH8kfNN8GPIBrAGxgIYXVCEGx6Bx4A036aAuf/r5WH9DIEdlmp7gHOYvSM6U87B0ag==",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/express-unless": "*"
+      }
+    },
     "node_modules/@types/express-serve-static-core": {
       "version": "4.17.19",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.19.tgz",
@@ -1569,6 +1595,14 @@
         "@types/node": "*",
         "@types/qs": "*",
         "@types/range-parser": "*"
+      }
+    },
+    "node_modules/@types/express-unless": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@types/express-unless/-/express-unless-0.5.1.tgz",
+      "integrity": "sha512-5fuvg7C69lemNgl0+v+CUxDYWVPSfXHhJPst4yTLcqi4zKJpORCxnDrnnilk3k0DTq/WrAUdvXFs01+vUqUZHw==",
+      "dependencies": {
+        "@types/express": "*"
       }
     },
     "node_modules/@types/graceful-fs": {
@@ -1813,9 +1847,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "10.17.56",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.56.tgz",
-      "integrity": "sha512-LuAa6t1t0Bfw4CuSR0UITsm1hP17YL+u82kfHGrHUWdhlBtH7sa7jGY5z7glGaIj/WDYDkRtgGd+KCjCzxBW1w=="
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.3.0.tgz",
+      "integrity": "sha512-8/bnjSZD86ZfpBsDlCIkNXIvm+h6wi9g7IqL+kmFkQ+Wvu3JrasgLElfiPgoo8V8vVfnEi0QVS12gbl94h9YsQ=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.0",
@@ -3207,7 +3241,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
       "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-      "devOptional": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -4508,15 +4541,16 @@
       }
     },
     "node_modules/firebase-admin": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-9.6.0.tgz",
-      "integrity": "sha512-GNrxsQsZ6alz9u+uYmX84qcixxYQnfOrByxVgEHWiCI9JSCbMOQ/1Px2A6+Coz5zzFokTgXsHnIg+Qz7hMlNZg==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-9.8.0.tgz",
+      "integrity": "sha512-v8B1qU8McZZT2hlLZ018TKz2FoKlfFkZq9mOIyzN7wJUOlAywqQX0JyqNpVGyPeU+B+77ojlvmkGTNXt2OFkgw==",
       "dependencies": {
-        "@firebase/database": "^0.8.1",
-        "@firebase/database-types": "^0.6.1",
-        "@types/node": "^10.10.0",
+        "@firebase/database": "^0.10.0",
+        "@firebase/database-types": "^0.7.2",
+        "@types/node": ">=12.12.47",
         "dicer": "^0.3.0",
         "jsonwebtoken": "^8.5.1",
+        "jwks-rsa": "^2.0.2",
         "node-forge": "^0.10.0"
       },
       "engines": {
@@ -4528,9 +4562,9 @@
       }
     },
     "node_modules/firebase-functions": {
-      "version": "3.13.2",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.13.2.tgz",
-      "integrity": "sha512-XHgAQZqA62awr4l9mNlJv6qnv5MkMkLuo+hafdW0T7IJj1PgrZtuIo5x+ib2npAcB0XhX5Sg0QR1hMYPAlfbaA==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.14.1.tgz",
+      "integrity": "sha512-hL/qm+i5i1qKYmAFMlQ4mwRngDkP+3YT3F4E4Nd5Hj2QKeawBdZiMGgEt6zqTx08Zq04vHiSnSM0z75UJRSg6Q==",
       "dependencies": {
         "@types/express": "4.17.3",
         "cors": "^2.8.5",
@@ -6470,6 +6504,20 @@
         "node": ">= 10.13.0"
       }
     },
+    "node_modules/jose": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-2.0.5.tgz",
+      "integrity": "sha512-BAiDNeDKTMgk4tvD0BbxJ8xHEHBZgpeRZ1zGPPsitSyMgjoMWiLGYAE7H7NpP5h0lPppQajQs871E8NHUrzVPA==",
+      "dependencies": {
+        "@panva/asn1.js": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.13.0 < 13 || >=13.7.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6689,6 +6737,21 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/jwks-rsa": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-2.0.3.tgz",
+      "integrity": "sha512-/rkjXRWAp0cS00tunsHResw68P5iTQru8+jHufLNv3JHc4nObFEndfEUSuPugh09N+V9XYxKUqi7QrkmCHSSSg==",
+      "dependencies": {
+        "@types/express-jwt": "0.0.42",
+        "debug": "^4.1.0",
+        "jose": "^2.0.5",
+        "limiter": "^1.1.5",
+        "lru-memoizer": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=10 < 13 || >=14"
+      }
+    },
     "node_modules/jws": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
@@ -6748,6 +6811,11 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/limiter": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
+    },
     "node_modules/lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
@@ -6792,6 +6860,11 @@
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
       "optional": true
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
@@ -6845,6 +6918,29 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/lru-memoizer": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.1.4.tgz",
+      "integrity": "sha512-IXAq50s4qwrOBrXJklY+KhgZF+5y98PDaNo0gi/v2KQBFLyWr+JyFvijZXkGKjQj/h9c0OwoE+JZbwUXce76hQ==",
+      "dependencies": {
+        "lodash.clonedeep": "^4.5.0",
+        "lru-cache": "~4.0.0"
+      }
+    },
+    "node_modules/lru-memoizer/node_modules/lru-cache": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
+      "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
+      "dependencies": {
+        "pseudomap": "^1.0.1",
+        "yallist": "^2.0.0"
+      }
+    },
+    "node_modules/lru-memoizer/node_modules/yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "node_modules/make-dir": {
       "version": "3.1.0",
@@ -7912,6 +8008,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "node_modules/psl": {
       "version": "1.8.0",
@@ -9820,7 +9921,8 @@
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -11168,45 +11270,59 @@
       }
     },
     "@firebase/app-types": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.6.1.tgz",
-      "integrity": "sha512-L/ZnJRAq7F++utfuoTKX4CLBG5YR7tFO3PLzG1/oXXKEezJ0kRL3CMRoueBEmTCzVb/6SIs2Qlaw++uDgi5Xyg=="
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.6.2.tgz",
+      "integrity": "sha512-2VXvq/K+n8XMdM4L2xy5bYp2ZXMawJXluUIDzUBvMthVR+lhxK4pfFiqr1mmDbv9ydXvEAuFsD+6DpcZuJcSSw=="
     },
     "@firebase/auth-interop-types": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.1.5.tgz",
-      "integrity": "sha512-88h74TMQ6wXChPA6h9Q3E1Jg6TkTHep2+k63OWg3s0ozyGVMeY+TTOti7PFPzq5RhszQPQOoCi59es4MaRvgCw==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.1.6.tgz",
+      "integrity": "sha512-etIi92fW3CctsmR9e3sYM3Uqnoq861M0Id9mdOPF6PWIg38BXL5k4upCNBggGUpLIS0H1grMOvy/wn1xymwe2g==",
       "requires": {}
     },
     "@firebase/component": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.21.tgz",
-      "integrity": "sha512-kd5sVmCLB95EK81Pj+yDTea8pzN2qo/1yr0ua9yVi6UgMzm6zAeih73iVUkaat96MAHy26yosMufkvd3zC4IKg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.0.tgz",
+      "integrity": "sha512-v18csWtXb0ri+3m7wuGLY/UDgcb89vuMlZGQ//+7jEPLIQeLbylvZhol1uzW9WzoOpxMxOS2W5qyVGX36wZvEA==",
       "requires": {
-        "@firebase/util": "0.3.4",
-        "tslib": "^1.11.1"
+        "@firebase/util": "1.1.0",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
       }
     },
     "@firebase/database": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.8.3.tgz",
-      "integrity": "sha512-i29rr3kcPltIkA8La9M1lgsSxx9bfu5lCQ0T+tbJptZ3UpqpcL1NzCcZa24cJjiLgq3HQNPyLvUvCtcPSFDlRg==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.10.1.tgz",
+      "integrity": "sha512-umT0kynJKc5VpVBOg3+YTDzdJORssh+QqPjoHfbSvtmgZizNiV8mgmKRcDhlVM6CisPb6v5xBn9l8JbK/WRQ1Q==",
       "requires": {
-        "@firebase/auth-interop-types": "0.1.5",
-        "@firebase/component": "0.1.21",
-        "@firebase/database-types": "0.6.1",
+        "@firebase/auth-interop-types": "0.1.6",
+        "@firebase/component": "0.5.0",
+        "@firebase/database-types": "0.7.2",
         "@firebase/logger": "0.2.6",
-        "@firebase/util": "0.3.4",
+        "@firebase/util": "1.1.0",
         "faye-websocket": "0.11.3",
-        "tslib": "^1.11.1"
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
       }
     },
     "@firebase/database-types": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.6.1.tgz",
-      "integrity": "sha512-JtL3FUbWG+bM59iYuphfx9WOu2Mzf0OZNaqWiQ7lJR8wBe7bS9rIm9jlBFtksB7xcya1lZSQPA/GAy2jIlMIkA==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.7.2.tgz",
+      "integrity": "sha512-cdAd/dgwvC0r3oLEDUR+ULs1vBsEvy0b27nlzKhU6LQgm9fCDzgaH9nFGv8x+S9dly4B0egAXkONkVoWcOAisg==",
       "requires": {
-        "@firebase/app-types": "0.6.1"
+        "@firebase/app-types": "0.6.2"
       }
     },
     "@firebase/logger": {
@@ -11215,11 +11331,18 @@
       "integrity": "sha512-KIxcUvW/cRGWlzK9Vd2KB864HlUnCfdTH0taHE0sXW5Xl7+W68suaeau1oKNEqmc3l45azkd4NzXTCWZRZdXrw=="
     },
     "@firebase/util": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.3.4.tgz",
-      "integrity": "sha512-VwjJUE2Vgr2UMfH63ZtIX9Hd7x+6gayi6RUXaTqEYxSbf/JmehLmAEYSuxS/NckfzAXWeGnKclvnXVibDgpjQQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.1.0.tgz",
+      "integrity": "sha512-lfuSASuPKNdfebuFR8rjFamMQUPH9iiZHcKS755Rkm/5gRT0qC7BMhCh3ZkHf7NVbplzIc/GhmX2jM+igDRCag==",
       "requires": {
-        "tslib": "^1.11.1"
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
       }
     },
     "@google-cloud/common": {
@@ -11313,12 +11436,6 @@
         "semver": "^6.2.0"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "14.14.37",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
-          "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==",
-          "optional": true
-        },
         "google-auth-library": {
           "version": "6.1.6",
           "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.6.tgz",
@@ -11642,6 +11759,11 @@
         "fastq": "^1.6.0"
       }
     },
+    "@panva/asn1.js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@panva/asn1.js/-/asn1.js-1.0.0.tgz",
+      "integrity": "sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw=="
+    },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -11798,6 +11920,15 @@
         "@types/serve-static": "*"
       }
     },
+    "@types/express-jwt": {
+      "version": "0.0.42",
+      "resolved": "https://registry.npmjs.org/@types/express-jwt/-/express-jwt-0.0.42.tgz",
+      "integrity": "sha512-WszgUddvM1t5dPpJ3LhWNH8kfNN8GPIBrAGxgIYXVCEGx6Bx4A036aAuf/r5WH9DIEdlmp7gHOYvSM6U87B0ag==",
+      "requires": {
+        "@types/express": "*",
+        "@types/express-unless": "*"
+      }
+    },
     "@types/express-serve-static-core": {
       "version": "4.17.19",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.19.tgz",
@@ -11806,6 +11937,14 @@
         "@types/node": "*",
         "@types/qs": "*",
         "@types/range-parser": "*"
+      }
+    },
+    "@types/express-unless": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@types/express-unless/-/express-unless-0.5.1.tgz",
+      "integrity": "sha512-5fuvg7C69lemNgl0+v+CUxDYWVPSfXHhJPst4yTLcqi4zKJpORCxnDrnnilk3k0DTq/WrAUdvXFs01+vUqUZHw==",
+      "requires": {
+        "@types/express": "*"
       }
     },
     "@types/graceful-fs": {
@@ -12022,9 +12161,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.17.56",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.56.tgz",
-      "integrity": "sha512-LuAa6t1t0Bfw4CuSR0UITsm1hP17YL+u82kfHGrHUWdhlBtH7sa7jGY5z7glGaIj/WDYDkRtgGd+KCjCzxBW1w=="
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.3.0.tgz",
+      "integrity": "sha512-8/bnjSZD86ZfpBsDlCIkNXIvm+h6wi9g7IqL+kmFkQ+Wvu3JrasgLElfiPgoo8V8vVfnEi0QVS12gbl94h9YsQ=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -13085,7 +13224,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
       "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-      "devOptional": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -14130,24 +14268,25 @@
       }
     },
     "firebase-admin": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-9.6.0.tgz",
-      "integrity": "sha512-GNrxsQsZ6alz9u+uYmX84qcixxYQnfOrByxVgEHWiCI9JSCbMOQ/1Px2A6+Coz5zzFokTgXsHnIg+Qz7hMlNZg==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-9.8.0.tgz",
+      "integrity": "sha512-v8B1qU8McZZT2hlLZ018TKz2FoKlfFkZq9mOIyzN7wJUOlAywqQX0JyqNpVGyPeU+B+77ojlvmkGTNXt2OFkgw==",
       "requires": {
-        "@firebase/database": "^0.8.1",
-        "@firebase/database-types": "^0.6.1",
+        "@firebase/database": "^0.10.0",
+        "@firebase/database-types": "^0.7.2",
         "@google-cloud/firestore": "^4.5.0",
         "@google-cloud/storage": "^5.3.0",
-        "@types/node": "^10.10.0",
+        "@types/node": ">=12.12.47",
         "dicer": "^0.3.0",
         "jsonwebtoken": "^8.5.1",
+        "jwks-rsa": "^2.0.2",
         "node-forge": "^0.10.0"
       }
     },
     "firebase-functions": {
-      "version": "3.13.2",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.13.2.tgz",
-      "integrity": "sha512-XHgAQZqA62awr4l9mNlJv6qnv5MkMkLuo+hafdW0T7IJj1PgrZtuIo5x+ib2npAcB0XhX5Sg0QR1hMYPAlfbaA==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.14.1.tgz",
+      "integrity": "sha512-hL/qm+i5i1qKYmAFMlQ4mwRngDkP+3YT3F4E4Nd5Hj2QKeawBdZiMGgEt6zqTx08Zq04vHiSnSM0z75UJRSg6Q==",
       "requires": {
         "@types/express": "4.17.3",
         "cors": "^2.8.5",
@@ -15603,6 +15742,14 @@
         "supports-color": "^7.0.0"
       }
     },
+    "jose": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-2.0.5.tgz",
+      "integrity": "sha512-BAiDNeDKTMgk4tvD0BbxJ8xHEHBZgpeRZ1zGPPsitSyMgjoMWiLGYAE7H7NpP5h0lPppQajQs871E8NHUrzVPA==",
+      "requires": {
+        "@panva/asn1.js": "^1.0.0"
+      }
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -15787,6 +15934,18 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "jwks-rsa": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-2.0.3.tgz",
+      "integrity": "sha512-/rkjXRWAp0cS00tunsHResw68P5iTQru8+jHufLNv3JHc4nObFEndfEUSuPugh09N+V9XYxKUqi7QrkmCHSSSg==",
+      "requires": {
+        "@types/express-jwt": "0.0.42",
+        "debug": "^4.1.0",
+        "jose": "^2.0.5",
+        "limiter": "^1.1.5",
+        "lru-memoizer": "^2.1.2"
+      }
+    },
     "jws": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
@@ -15831,6 +15990,11 @@
         "type-check": "~0.4.0"
       }
     },
+    "limiter": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
+    },
     "lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
@@ -15869,6 +16033,11 @@
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
       "optional": true
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.includes": {
       "version": "4.3.0",
@@ -15918,6 +16087,31 @@
       "devOptional": true,
       "requires": {
         "yallist": "^4.0.0"
+      }
+    },
+    "lru-memoizer": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.1.4.tgz",
+      "integrity": "sha512-IXAq50s4qwrOBrXJklY+KhgZF+5y98PDaNo0gi/v2KQBFLyWr+JyFvijZXkGKjQj/h9c0OwoE+JZbwUXce76hQ==",
+      "requires": {
+        "lodash.clonedeep": "^4.5.0",
+        "lru-cache": "~4.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
+          "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
+          "requires": {
+            "pseudomap": "^1.0.1",
+            "yallist": "^2.0.0"
+          }
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+        }
       }
     },
     "make-dir": {
@@ -16719,6 +16913,11 @@
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.9.1"
       }
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
       "version": "1.8.0",
@@ -18206,7 +18405,8 @@
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "tsutils": {
       "version": "3.21.0",

--- a/functions/package.json
+++ b/functions/package.json
@@ -20,8 +20,8 @@
     "@algolia/client-common": "^4.8.6",
     "@algolia/transporter": "^4.8.6",
     "algoliasearch": "^4.8.6",
-    "firebase-admin": "^9.5.0",
-    "firebase-functions": "^3.13.2"
+    "firebase-admin": "^9.8.0",
+    "firebase-functions": "^3.14.1"
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.13.0",


### PR DESCRIPTION
`firebase-functions` 3.14.1 introduces a new Cloud Function location: `Warsaw (europe-central2)`

This PR should:
- update `firebase-admin` to 9.8.0
- update `firebase-functions` to 3.14.1
- add the new location to the list of locations that developers can choose from when configuring the extension.