### PR TITLE
Adding externalServices

### DIFF
--- a/extension.yaml
+++ b/extension.yaml
@@ -28,6 +28,9 @@ contributors:
     email: sajid.momin@algolia.com
     url: https://github.com/smomin
 
+externalServices:
+  - name: Algolia
+    pricingUri: https://algolia.com/pricing
 
 # Public URL for the source code of your extension
 sourceUrl: https://github.com/algolia/firestore-algolia-search/tree/main


### PR DESCRIPTION
Adding externalServices field to extension.yaml.

This is a migration of an existing field that used to live in https://extensions-registry.firebaseapp.com/extensions.json . It is shown to users during extension installation.
<img width="775" alt="Screen Shot 2021-10-05 at 4 59 21 PM" src="https://user-images.githubusercontent.com/4635763/136119881-80ff8c73-0653-46f1-8d6c-633e90ef208e.png">

Feel free to edit this field if a different link or API name is more appropriate!