### PR TITLE
Changed API key to type 'secret'

### DIFF
--- a/extension.yaml
+++ b/extension.yaml
@@ -110,7 +110,7 @@ params:
       We recommend [creating a new API key](https://www.algolia.com/doc/guides/security/api-keys/#creating-and-managing-api-keys)
       with "addObject", "deleteObject", "listIndexes", "deleteIndex", "editSettings", and "settings" permissions.
       **Do not use the Admin API key**.
-    type: string
+    type: secret
     required: true
 
   - param: TRANSFORM_FUNCTION


### PR DESCRIPTION
Firebase extensions now support storing keys and secrets in Google Secret Manager. (https://firebase.google.com/docs/extensions/manage-installed-extensions?platform=cli#view-extension-secrets)

Changed the type of the `ALGOLIA_API_KEY` param to 'secret' instead of 'text'. I am not sure if this will break existing installations.

(this is my first PR on an open source repository so apologies in advance if I might have missed something!)