### PR TITLE
docs: add disclaimer about space between fields

### DIFF
--- a/POSTINSTALL.md
+++ b/POSTINSTALL.md
@@ -54,6 +54,7 @@ Run the import process using `npx`.
         npx firestore-algolia-search
       ```
       **NOTE**: In the above multiline command, make sure that the `\` is at the end of each line, except for the last.
+      **NOTE**: Make sure that there is no space inbetween the specified `FIELDS`. E.g. `name,category,views` ✅ | `name, category, views` ❌.
 ### Monitoring
 
 As a best practice, you can [monitor the activity](https://firebase.google.com/docs/extensions/manage-installed-extensions#monitor) of your installed extension, including checks on its health, usage, and logs.


### PR DESCRIPTION
When specifying multiple fields, firebase auto-fills `${param:FIELDS}` with a comma separated list of the previously specified fields like so:
`name, category, views`
Copying and executing this in the command line leads to an error, stating `name is not a Command`. This disclaimer will lead to less confusion.