### PR TITLE
Update contributing guide to specify firebase tools version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 ### Installation
 Install the Firebase tools in order to maintain this extension.
 ```
-npm install -g firebase-tools
+npm install -g firebase-tools@10.9.2
 ```
 
 ### Authentication


### PR DESCRIPTION
Since the latest version of [firebase-tools v11.x.x](https://github.com/firebase/firebase-tools/releases/tag/v11.0.0) the emulator has been removed. 

By enforcing the version number of the firebase-tool we ensure we are still able to emulate a local environment with the extension.

ps: I made the same change [here](https://github.com/meilisearch/firestore-meilisearch/pull/95), hope it avoids you wasting time finding the issue :) 