### PR TITLE
Alt object ID Impl

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ Cloud Functions Location: Where do you want to deploy the functions created for 
   where the records will be persisted.
   Refer to [naming your index](https://www.algolia.com/doc/guides/sending-and-managing-data/send-and-update-your-data/#naming-your-index) for more information.
 
+- Alternative Object Id: Are you looking to use another Firestore document property or document path as the Algolia ObjectID?
+  Specify an alternative Firestore document property to use for the Algolia record Id.  Use `(path)` if the document path is desired as the Algolia ObjectID.  The default is the Firestore document Id.
+  **If you set this property, make sure to clear out the Algolia Index since the ObjectID will be different resulting in duplicate records.**
+
 - Transform Function Name (experimental): What is the Firebase Cloud Function Name?
   This is the name of the Firestore Cloud Function for transforming the data before transmitting to Algolia for indexing.
   This function should be deployed to the same Firebase Project and Location as the Firestore/Algolia extension.

--- a/extension.yaml
+++ b/extension.yaml
@@ -5,7 +5,7 @@
 name: firestore-algolia-search
 
 # Follow semver versioning
-version: 1.2.0
+version: 1.2.1-rc.1
 
 # Version of the Firebase Extensions specification
 specVersion: v1beta

--- a/extension.yaml
+++ b/extension.yaml
@@ -93,7 +93,7 @@ params:
     default: ''
     example: store
     validationRegex: "^[^/]+(/[^/]+/[^/]+)*$"
-    validationErrorMessage: Firestore collection paths must be an odd number of segments separated by slashes, e.g. "path/to/collection".
+    validationErrorMessage: Firestore collection paths must be an odd number of segments separated by slashes, e.g. "movies/{id}/actors".
     required: true
     immutable: true
 
@@ -148,6 +148,14 @@ params:
       **Do not use the Admin API key**.
     type: secret
     required: true
+
+  - param: ALT_OBJECT_ID
+    label: Alternative Object Id
+    description: >-
+      Specify an alternative Firestore document property to use for the Algolia record Id.  Use `(path)` if the document path is desired as the Algolia ObjectID.  The default is the Firestore document Id.
+      **If you set this property, make sure to clear out the Algolia Index since the ObjectID will be different resulting in duplicate records.**
+    type: string
+    required: false
 
   - param: TRANSFORM_FUNCTION
     label: Transform Function Name (Experimental)

--- a/firebase.json
+++ b/firebase.json
@@ -31,6 +31,7 @@
     "firestore-algolia-search": ".",
     "firestore-algolia-search-s4eg": ".",
     "firestore-algolia-search-z5tb": ".",
-    "firestore-algolia-search-lq9c": "."
+    "firestore-algolia-search-lq9c": ".",
+    "firestore-algolia-search-2n5t": "."
   }
 }

--- a/firebase.json
+++ b/firebase.json
@@ -30,6 +30,7 @@
   "extensions": {
     "firestore-algolia-search": ".",
     "firestore-algolia-search-s4eg": ".",
-    "firestore-algolia-search-z5tb": "."
+    "firestore-algolia-search-z5tb": ".",
+    "firestore-algolia-search-lq9c": "."
   }
 }

--- a/functions/__tests__/data/document.ts
+++ b/functions/__tests__/data/document.ts
@@ -2,10 +2,12 @@ import { firestore } from 'firebase-admin';
 import Timestamp = firestore.Timestamp;
 
 export const documentID = 'document/1';
+export const recordID = 'e90db247-5eef-4bb9-875e-67e291be6356';
 
 export const testReleaseDate = new Date(1995, 12, 1);
 
 export default {
+  'id': recordID,
   'title': 'The Shawshank Redemption',
   'alternative_titles': [
     'En verden udenfor',

--- a/functions/__tests__/functions.create.alt.object.id.test.ts
+++ b/functions/__tests__/functions.create.alt.object.id.test.ts
@@ -1,0 +1,98 @@
+import * as functionsTestInit from 'firebase-functions-test';
+import mockedEnv from 'mocked-env';
+import testDocument, { documentID, recordID, testReleaseDate } from './data/document';
+import { mockedPartialUpdateObject } from './mocks/search';
+
+let restoreEnv;
+let functionsTest = functionsTestInit();
+
+describe('extension', () => {
+  globalThis.mockSearchModule();
+  const defaultEnvironment = globalThis.defaultEnvironment;
+
+  let config;
+  beforeEach(() => {
+    restoreEnv = mockedEnv({ ...defaultEnvironment, ALT_OBJECT_ID: 'id' });
+    config = require('../src/config').default;
+  });
+
+  describe('functions.executeIndexOperation', () => {
+    const logger = globalThis.mockLogger();
+    const infoMock = logger.info;
+    let functionsConfig;
+
+    beforeEach(async () => {
+      jest.clearAllMocks();
+      functionsTest = functionsTestInit();
+      functionsConfig = config;
+    });
+
+    test('functions runs with a create with Alt Object ID', async () => {
+      const beforeSnapshot = globalThis.snapshot({}, documentID);
+      const afterSnapshot = globalThis.snapshot(testDocument, documentID);
+
+      const documentChange = globalThis.makeChange(
+        beforeSnapshot,
+        afterSnapshot
+      );
+
+      const data = {};
+      const callResult = await globalThis.mockIndexerResult(documentChange, data);
+
+      expect(callResult).toBeUndefined();
+
+      const payload = {
+        'objectID': recordID,
+        'path': afterSnapshot.ref.path,
+        'title': afterSnapshot.data().title,
+        'awards': [
+          'awards/1'
+        ],
+        'meta': {
+          'releaseDate': testReleaseDate.getTime()
+        },
+        'lastmodified': {
+          '_operation': 'IncrementSet',
+          'value': expect.any(Number)
+        }
+      };
+
+      expect(mockedPartialUpdateObject).toBeCalledWith(payload, { createIfNotExists: true });
+    });
+  });
+
+  test('functions runs with a create with Alt Object ID using document path', async () => {
+    config.altObjectId = '(path)';
+
+    const beforeSnapshot = globalThis.snapshot({}, documentID);
+    const afterSnapshot = globalThis.snapshot(testDocument, documentID);
+
+    const documentChange = globalThis.makeChange(
+      beforeSnapshot,
+      afterSnapshot
+    );
+
+    const data = {};
+    const callResult = await globalThis.mockIndexerResult(documentChange, data);
+
+    expect(callResult).toBeUndefined();
+
+    const payload = {
+      'objectID': documentID,
+      'path': afterSnapshot.ref.path,
+      'title': afterSnapshot.data().title,
+      'awards': [
+        'awards/1'
+      ],
+      'meta': {
+        'releaseDate': testReleaseDate.getTime()
+      },
+      'lastmodified': {
+        '_operation': 'IncrementSet',
+        'value': expect.any(Number)
+      }
+    };
+
+    expect(mockedPartialUpdateObject).toBeCalledWith(payload, { createIfNotExists: true });
+  });
+});

--- a/functions/src/config.ts
+++ b/functions/src/config.ts
@@ -27,6 +27,7 @@ const config = {
   transformFunction: process.env.TRANSFORM_FUNCTION,
   projectId: process.env.PROJECT_ID,
   doFullIndexing: process.env.DO_FULL_INDEXING == 'true',
+  altObjectId: process.env.ALT_OBJECT_ID
 };
 
 export type Config = typeof config;

--- a/functions/src/extract.ts
+++ b/functions/src/extract.ts
@@ -30,7 +30,7 @@ const getPayload = async (snapshot: DocumentSnapshot): Promise<any> => {
   let payload: {
     [key: string]: boolean | string | number;
   } = {
-    objectID: snapshot.id,
+    objectID: config.altObjectId ? config.altObjectId === '(path)' ? snapshot.ref.path : snapshot.get(config.altObjectId) : snapshot.id,
     path: snapshot.ref.path,
   };
 

--- a/functions/src/version.ts
+++ b/functions/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '1.2.0';
+export const version = '1.2.1-rc.1';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firestore-algolia-search",
-  "version": "1.2.0",
+  "version": "1.2.1-rc.1",
   "description": "",
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
- allow admin to use another document attribute as objectID
- allow admin to use document path as objectID
- update README.md for objectID attribute
- update README.md for sub collection path example