### PR TITLE
fix: delete aloglia index handling altObjectId

### DIFF
--- a/functions/src/extract.ts
+++ b/functions/src/extract.ts
@@ -26,11 +26,15 @@ const PAYLOAD_MAX_SIZE = 102400;
 const PAYLOAD_TOO_LARGE_ERR_MSG = 'Record is too large.';
 const trim = /^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g;
 
+export const getObjectID = (snapshot: DocumentSnapshot): string => {
+  return config.altObjectId ? config.altObjectId === '(path)' ? snapshot.ref.path : snapshot.get(config.altObjectId) : snapshot.id;
+}
+
 const getPayload = async (snapshot: DocumentSnapshot): Promise<any> => {
   let payload: {
     [key: string]: boolean | string | number;
   } = {
-    objectID: config.altObjectId ? config.altObjectId === '(path)' ? snapshot.ref.path : snapshot.get(config.altObjectId) : snapshot.id,
+    objectID: getObjectID(snapshot),
     path: snapshot.ref.path,
   };
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -26,7 +26,7 @@ import { firestore } from 'firebase-admin';
 import FieldPath = firestore.FieldPath;
 
 import config from './config';
-import extract from './extract';
+import extract, { getObjectID } from './extract';
 import { areFieldsUpdated, ChangeType, getChangeType } from './util';
 import { version } from './version';
 import * as logs from './logs';
@@ -122,8 +122,9 @@ const handleDeleteDocument = async (
   deleted: DocumentSnapshot,
 ) => {
   try {
-    logs.deleteIndex(deleted.id);
-    await index.deleteObject(deleted.id);
+    const deletedObjectID = getObjectID(deleted);
+    logs.deleteIndex(deletedObjectID);
+    await index.deleteObject(deletedObjectID);
   } catch (e) {
     logs.error(e);
   }


### PR DESCRIPTION
When I use altObjectId, create and update operations are working well but delete operation is not working. So I fix `index.deleteObject` to get objectID that handle altObjectID.

- In my case, I am using (path) to altObjectID in Firebase Extension.