### PR TITLE
Update node runtime to v22

### DIFF
--- a/extension.yaml
+++ b/extension.yaml
@@ -68,7 +68,7 @@ resources:
     properties: # LOCATION is a user-configured parameter value specified by the user
       # during installation.
       location: ${LOCATION}
-      runtime: nodejs18
+      runtime: nodejs22
       eventTrigger:
         eventType: providers/cloud.firestore/eventTypes/document.write
         resource: projects/${PROJECT_ID}/databases/${DATABASE_ID}/documents/${COLLECTION_PATH}/{documentID}
@@ -78,7 +78,7 @@ resources:
     description: Loads all the data from your FireStore database into Algolia
     properties:
       location: ${param:LOCATION}
-      runtime: nodejs18
+      runtime: nodejs22
       availableMemoryMb: 1024
       timeout: 540s
       taskQueueTrigger: { }

--- a/firebase.json
+++ b/firebase.json
@@ -12,7 +12,8 @@
       "predeploy": [
         "npm --prefix \"$RESOURCE_DIR\" run lint",
         "npm --prefix \"$RESOURCE_DIR\" run build"
-      ]
+      ],
+      "runtime": "nodejs22"
     }
   ],
   "emulators": {


### PR DESCRIPTION
## What does this PR do?
- Updates the Node.js runtime from v18 to v22.
- This update is necessary because Node.js 18 will reach its end of support on **April 30, 2025**, as per the [Google Cloud Support Schedule](https://cloud.google.com/appengine/docs/standard/lifecycle/support-schedule#nodejs).
- Ensures the project stays up-to-date with the latest stable Node.js version for better security, performance, and long-term support.
