### PR TITLE
docs: update SECURITY and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### [1.2.8](https://github.com/algolia/firestore-algolia-search/compare/v1.2.7...v1.2.8) (2025-03-21)
 
+### Bug Fixes
+
+* Update runtime to node22 ([7c4f5bc](https://github.com/algolia/firestore-algolia-search/commit/7c4f5bc24ea171c0aed1ecc1f50262e723ea26e1))
+
 ### [1.2.7](https://github.com/algolia/firestore-algolia-search/compare/v1.2.6...v1.2.7) (2024-07-04)
 
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,13 +3,19 @@
 ## Supported Versions
 
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 1.2.2   | :white_check_mark: |
-| 1.2.0   | :x:                |
-| 1.1.5   | :x:                |
-| 1.1.4   | :x:                |
-| < 1.1.3   | :white_check_mark: |
+| Version | Supported         |
+|---------|-------------------|
+| 1.2.8   | :white_check_mark: |
+| 1.2.7   | :x: |
+| 1.2.6   | :x:                  |
+| 1.2.5   | :x:               |
+| 1.2.4   | :x:               |
+| 1.2.3   | :x:               |
+| 1.2.2   | :x:               |
+| 1.2.0   | :x:               |
+| 1.1.5   | :x:               |
+| 1.1.4   | :x:               |
+| < 1.1.3 | :x: |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
* add additional versions to the SECURITY log on what version are support and not supported
* add CHANGELOG updates that were missing about the last release