### PR TITLE
fix: correctly detect collection group vs specific subcollection paths

### DIFF
--- a/functions/__tests__/util.test.ts
+++ b/functions/__tests__/util.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from '@jest/globals';
-import { getFields } from '../src/util';
+import { getFields, isCollectionGroupPath } from '../src/util';
 
 describe('getFields', () => {
   test('empty string', () => {
@@ -20,5 +20,39 @@ describe('getFields', () => {
       'field3',
       'field4',
     ]);
+  });
+});
+
+describe('isCollectionGroupPath', () => {
+  describe('should return false for specific collection paths', () => {
+    test('top-level collection', () => {
+      expect(isCollectionGroupPath('posts')).toBe(false);
+    });
+
+    test('specific subcollection path', () => {
+      expect(isCollectionGroupPath('organizations/acme/members')).toBe(false);
+    });
+
+    test('deeply nested specific path', () => {
+      expect(isCollectionGroupPath('companies/acme/departments/engineering/employees')).toBe(false);
+    });
+  });
+
+  describe('should return true for collection group patterns with wildcards', () => {
+    test('simple wildcard pattern', () => {
+      expect(isCollectionGroupPath('users/{userId}/posts')).toBe(true);
+    });
+
+    test('wildcard with different naming', () => {
+      expect(isCollectionGroupPath('users/{uid}/comments')).toBe(true);
+    });
+
+    test('multiple wildcards', () => {
+      expect(isCollectionGroupPath('organizations/{orgId}/teams/{teamId}/members')).toBe(true);
+    });
+
+    test('wildcard at start', () => {
+      expect(isCollectionGroupPath('{parentId}/subcollection')).toBe(true);
+    });
   });
 });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -177,17 +177,6 @@ export const executeFullIndexOperation = functions.tasks
     const startTime = (data['startTime'] as number) ?? Date.now();
     let query: firebase.firestore.Query;
 
-    // Determine if this is a collection group query by checking for wildcard patterns.
-    //
-    // Collection group patterns contain wildcards like {docId}:
-    //   - "users/{userId}/posts" → queries all "posts" subcollections across all users
-    //   - "organizations/{orgId}/members" → queries all "members" subcollections
-    //
-    // Specific paths do NOT contain wildcards:
-    //   - "posts" → top-level collection
-    //   - "organizations/acme/members" → specific subcollection under a specific document
-    //
-    // The previous logic incorrectly treated any path with '/' as a collection group.
     const isCollectionGroup = isCollectionGroupPath(config.collectionPath);
     logs.info('Is Collection Group?', isCollectionGroup);
     if (isCollectionGroup) {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -27,7 +27,7 @@ import FieldPath = firestore.FieldPath;
 
 import config from './config';
 import extract from './extract';
-import { areFieldsUpdated, ChangeType, getChangeType, getObjectID } from './util';
+import { areFieldsUpdated, ChangeType, getChangeType, getObjectID, isCollectionGroupPath } from './util';
 import { version } from './version';
 import * as logs from './logs';
 
@@ -177,7 +177,18 @@ export const executeFullIndexOperation = functions.tasks
     const startTime = (data['startTime'] as number) ?? Date.now();
     let query: firebase.firestore.Query;
 
-    const isCollectionGroup = config.collectionPath.indexOf('/') !== -1;
+    // Determine if this is a collection group query by checking for wildcard patterns.
+    //
+    // Collection group patterns contain wildcards like {docId}:
+    //   - "users/{userId}/posts" → queries all "posts" subcollections across all users
+    //   - "organizations/{orgId}/members" → queries all "members" subcollections
+    //
+    // Specific paths do NOT contain wildcards:
+    //   - "posts" → top-level collection
+    //   - "organizations/acme/members" → specific subcollection under a specific document
+    //
+    // The previous logic incorrectly treated any path with '/' as a collection group.
+    const isCollectionGroup = isCollectionGroupPath(config.collectionPath);
     logs.info('Is Collection Group?', isCollectionGroup);
     if (isCollectionGroup) {
       query = firestoreDB

--- a/functions/src/util.ts
+++ b/functions/src/util.ts
@@ -78,13 +78,16 @@ export const isValidValue = (value) => {
 };
 
 /**
- * Determines if a collection path represents a collection group query.
+ * Determines if a collection path represents a collection group query by checking for wildcard patterns.
  *
  * Collection group queries use wildcard syntax like "users/{userId}/posts" to query
- * all subcollections with a given name across the database.
+ * all subcollections with a given name across the database:
+ *   - "users/{userId}/posts" → queries all "posts" subcollections across all users
+ *   - "organizations/{orgId}/members" → queries all "members" subcollections
  *
- * Specific paths like "organizations/acme/members" should NOT be treated as collection
- * groups, as they reference a specific subcollection under a specific document.
+ * Specific paths like "organizations/acme/members" should NOT be treated as collection groups:
+ *   - "posts" → top-level collection
+ *   - "organizations/acme/members" → specific subcollection under a specific document
  *
  * @param collectionPath - The configured collection path
  * @returns true if the path contains wildcard patterns (e.g., {userId}), false otherwise

--- a/functions/src/util.ts
+++ b/functions/src/util.ts
@@ -76,3 +76,20 @@ export const areFieldsUpdated = (
 export const isValidValue = (value) => {
   return typeof value !== undefined && value !== null;
 };
+
+/**
+ * Determines if a collection path represents a collection group query.
+ *
+ * Collection group queries use wildcard syntax like "users/{userId}/posts" to query
+ * all subcollections with a given name across the database.
+ *
+ * Specific paths like "organizations/acme/members" should NOT be treated as collection
+ * groups, as they reference a specific subcollection under a specific document.
+ *
+ * @param collectionPath - The configured collection path
+ * @returns true if the path contains wildcard patterns (e.g., {userId}), false otherwise
+ */
+export const isCollectionGroupPath = (collectionPath: string): boolean => {
+  // Check for wildcard patterns like {userId}, {docId}, etc.
+  return /\{[^}]+\}/.test(collectionPath);
+};


### PR DESCRIPTION
## Summary

Fixes #229

The "Full Index existing documents" feature incorrectly treats any path containing `/` as a collection group query, causing `organizations/acme/members` to index ALL `members` subcollections instead of just that specific one.

### Why live triggers work correctly

Live triggers use `functions.firestore.document(config.collectionPath)`, which is Firebase's Cloud Functions trigger API—not a Firestore query. This API **natively interprets wildcard patterns** like `{userId}` when setting up event listeners, so it handles all path types correctly without any detection logic.

### Why full indexing needs manual detection

Full indexing uses Firestore's query APIs, which have no wildcard support:
- `firestore.collection(path)` - queries a specific collection path
- `firestore.collectionGroup(id)` - queries ALL collections with that ID (no path, just the final collection name)

There's no API that takes `users/{userId}/posts` and automatically does a collection group query—we must detect wildcards and choose the right API ourselves.

### The fix

Check for wildcard patterns (`{userId}`, `{docId}`) to correctly choose:
- `organizations/acme/members` → `.collection('organizations/acme/members')`
- `users/{userId}/posts` → `.collectionGroup('posts')`

## Documentation suggestion

[Can I index sub-collection from Firestore?](https://support.algolia.com/hc/en-us/articles/23878984008337-Can-I-index-sub-collection-from-Firestore) should clarify:
- **Specific path** (`organizations/acme/members`): indexes only that subcollection  
- **Wildcard pattern** (`organizations/{orgId}/members`): indexes all matching subcollections
