### PR TITLE
chore: update runtime to nodejs22

### DIFF
--- a/extension.yaml
+++ b/extension.yaml
@@ -68,7 +68,7 @@ resources:
     properties: # LOCATION is a user-configured parameter value specified by the user
       # during installation.
       location: ${LOCATION}
-      runtime: nodejs20
+      runtime: nodejs22
       eventTrigger:
         eventType: providers/cloud.firestore/eventTypes/document.write
         resource: projects/${PROJECT_ID}/databases/${DATABASE_ID}/documents/${COLLECTION_PATH}/{documentID}
@@ -78,7 +78,7 @@ resources:
     description: Loads all the data from your FireStore database into Algolia
     properties:
       location: ${param:LOCATION}
-      runtime: nodejs20
+      runtime: nodejs22
       availableMemoryMb: 1024
       timeout: 540s
       taskQueueTrigger: { }


### PR DESCRIPTION
## Summary

Bumps the Cloud Functions runtime in `extension.yaml` from `nodejs20` to `nodejs22`, aligning with `firebase.json` (which already targets `nodejs22`).

## Context

- PR #233 originally bumped the runtime to `nodejs22`.
- PR #239 then downgraded `extension.yaml` to `nodejs20` to resolve an installation issue, while `firebase.json` was left at `nodejs22`. This left the two configs out of sync.
- Node.js 20 is approaching maintenance EOL; `nodejs22` is now generally available for Firebase Extensions.

If the installation issue that motivated #239 is still reproducible, feel free to close — I wasn't able to verify the original failure mode. Otherwise this re-aligns the runtime configs.

## Test plan

- [x] `cd functions && npm install && npm test` — **all 25 tests pass across 9 suites** under Node.js 22.22.2
- [ ] Maintainer: verify extension still installs cleanly via `firebase ext:install . --project=<test-project>`

No version bump included — release/version bumps are owned by maintainers per `CONTRIBUTING.md` (`npm run release`).