### PR TITLE
chore: update runtime to nodejs22 and skip jest during deploy

### DIFF
--- a/extension.yaml
+++ b/extension.yaml
@@ -68,7 +68,7 @@ resources:
     properties: # LOCATION is a user-configured parameter value specified by the user
       # during installation.
       location: ${LOCATION}
-      runtime: nodejs20
+      runtime: nodejs22
       eventTrigger:
         eventType: providers/cloud.firestore/eventTypes/document.write
         resource: projects/${PROJECT_ID}/databases/${DATABASE_ID}/documents/${COLLECTION_PATH}/{documentID}
@@ -78,7 +78,7 @@ resources:
     description: Loads all the data from your FireStore database into Algolia
     properties:
       location: ${param:LOCATION}
-      runtime: nodejs20
+      runtime: nodejs22
       availableMemoryMb: 1024
       timeout: 540s
       taskQueueTrigger: { }

--- a/functions/package.json
+++ b/functions/package.json
@@ -7,7 +7,7 @@
     "clean": "rimraf lib",
     "compile": "tsc",
     "lint": "pretty-quick --staged && lint-staged",
-    "prepare": "npm run build",
+    "prepare": "npm run clean && npm run compile",
     "test": "jest --coverage"
   },
   "hooks": {


### PR DESCRIPTION
## Summary

Bumps the Cloud Functions runtime in `extension.yaml` from `nodejs20` to `nodejs22`, aligning with `firebase.json` (which already targets `nodejs22`), and stops the jest suite from running inside the Firebase Cloud Build sandbox during deploy.

## Context

- PR #233 originally bumped the runtime to `nodejs22`.
- PR #239 then downgraded `extension.yaml` to `nodejs20` to resolve an installation issue, while `firebase.json` was left at `nodejs22` — the two configs have been out of sync ever since.
- Node.js 20 is approaching maintenance EOL; `nodejs22` is now generally available for Firebase Extensions.

### What's different from PR #233 / the prior `nodejs22` attempt

Re-applying the runtime bump alone reproduces the failure that motivated #239's downgrade. The Cloud Build log shows tests failing inside the deploy sandbox with `TS2306: '/workspace/src/version.ts' is not a module` from ts-jest, which aborts installation. The root cause isn't the runtime: `functions/package.json` had `"prepare": "npm run build"`, and `build` chains `clean && test && compile`. npm fires `prepare` automatically after `npm install`, so the deploy was running the full jest suite — and any ts-jest hiccup in the sandbox (which doesn't reproduce locally) breaks installation.

This PR narrows `prepare` to `clean && compile`. `npm run build` is unchanged, so local and CI builds still run the full pipeline including tests.

## Test plan

- [x] `cd functions && npm install && npm test` — all 25 tests pass across 9 suites under Node.js 22.22.2
- [x] In an isolated copy of `functions/`, `npm install` (which now fires the slimmed `prepare`) produces `lib/*.js` with no test execution
- [ ] Maintainer: verify extension installs cleanly via `firebase ext:install . --project=<test-project>` on Node.js 22

No version bump included — release/version bumps are owned by maintainers per `CONTRIBUTING.md` (`npm run release`).