### PR TITLE
fix: migrate executeIndexOperation to Gen 2 for eur3/nam5 multi-region support

### DIFF
--- a/functions/__tests__/mocks/search.ts
+++ b/functions/__tests__/mocks/search.ts
@@ -35,9 +35,14 @@ export const mockSearchModule = () => {
 };
 
 export const mockIndexerResult = (document, data) => {
-  console.log('mockIndexerResult');
   const indexer = mockIndexer();
-
-  console.log('indexer', indexer);
-  return indexer(document, data);
+  // Convert Gen 1 Change to Gen 2 CloudEvent format for onDocumentWritten
+  const event = {
+    data: {
+      before: document.before,
+      after: document.after,
+    },
+    time: new Date().toISOString(),
+  };
+  return indexer(event);
 };

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -17,7 +17,7 @@
 
 import algoliaSearch from 'algoliasearch';
 import * as functions from 'firebase-functions';
-import { EventContext } from 'firebase-functions';
+import { onDocumentWritten } from 'firebase-functions/v2/firestore';
 import { DocumentData, DocumentSnapshot, getFirestore } from 'firebase-admin/firestore';
 import { getExtensions } from 'firebase-admin/extensions';
 import { getFunctions } from 'firebase-admin/functions';
@@ -129,15 +129,21 @@ const handleDeleteDocument = async (
   }
 };
 
-// export const executeIndexOperation = functions.handler.firestore.document
-//   .onWrite(async (change: Change<DocumentSnapshot>, context: EventContext): Promise<void> => {
-export const executeIndexOperation = functions.firestore
-  .document(config.collectionPath)
-  .onWrite(async (change, context: EventContext): Promise<void> => {
+export const executeIndexOperation = onDocumentWritten(
+  {
+    document: `${config.collectionPath}/{documentID}`,
+    database: config.databaseId,
+    region: config.location,
+  },
+  async (event): Promise<void> => {
     logs.start();
 
-    const eventTimestamp = Date.parse(context.timestamp);
-    const changeType = getChangeType(change);
+    const eventTimestamp = Date.parse(event.time);
+    const change = {
+      before: event.data!.before,
+      after: event.data!.after,
+    };
+    const changeType = getChangeType(change as unknown as functions.Change<DocumentSnapshot>);
     switch (changeType) {
       case ChangeType.CREATE:
         await handleCreateDocument(change.after, eventTimestamp);
@@ -149,10 +155,11 @@ export const executeIndexOperation = functions.firestore
         await handleUpdateDocument(change.before, change.after, eventTimestamp);
         break;
       default: {
-        throw new Error(`Invalid change type: ${ changeType }`);
+        throw new Error(`Invalid change type: ${changeType}`);
       }
     }
-  });
+  },
+);
 
 export const executeFullIndexOperation = functions.tasks
   .taskQueue()


### PR DESCRIPTION
## Problem

The Gen 1 Cloud Functions control plane cannot parse the `eur3-europe-west1` composite 
region identifier that GCP now assigns to Firestore databases in the `eur3` multi-region.
This causes the extension installation to fail with:

Gen1 operation for function .../ext-firestore-algolia-search-executeIndexOperation failed:
Resource .../databases/(default)/documents/<collection>/{documentID}
is in region eur3-europe-west1 which is not supported.

This has been confirmed by Google Cloud Support as a permanent limitation — the Gen 1 
control plane is reaching end-of-life (final runtime: Node.js 22) and there are no plans 
to update it to support modern multi-region identifiers. All new Firebase projects in `eur3` 
and `nam5` multi-regions are affected, regardless of how the project is provisioned.

Related issue: #251

## Fix

Migrate `executeIndexOperation` from Gen 1 (`functions.firestore.document().onWrite()`) 
to Gen 2 (`onDocumentWritten` from `firebase-functions/v2/firestore`).

`executeFullIndexOperation` (task queue / full re-index) is unaffected and remains Gen 1.

## ⚠️ Known issue with Eventarc triggers (post-install manual step required)

Firebase Extensions auto-creates Eventarc triggers without `operator: match-path-pattern` 
on the document filter. This means the document path is treated as a literal string instead 
of a wildcard — the trigger registers successfully but never fires.

After installing the extension, you must delete the auto-created triggers and recreate 
them manually:

gcloud eventarc triggers delete <auto-created-trigger-name> --location=<region> --quiet

gcloud eventarc triggers create algolia-trigger \
  --location=<firestore-region> \
  --event-filters="type=google.cloud.firestore.document.v1.written" \
  --event-filters="database=(default)" \
  --event-filters-path-pattern="document=<collectionPath>/{documentID}" \
  --destination-run-service=ext-firestore-algolia-search-executeindexoperation \
  --destination-run-region=<functions-region> \
  --service-account=<project-number>-compute@developer.gserviceaccount.com

Note: `--event-filters-path-pattern` sets `operator: match-path-pattern` which is required 
for wildcard document matching. This is a separate bug in how Firebase Extensions creates 
Eventarc triggers.

## Testing

Tested on Firebase projects in `eur3` multi-region where Gen 1 trigger registration 
was permanently broken. Real-time sync confirmed working (<15s Firestore write → Algolia).
All 25 existing tests pass.

Use at your own risk — validated on our setup but not tested across all extension 
configuration combinations.