### PR TITLE
chore(release): 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.3.0](https://github.com/algolia/firestore-algolia-search/compare/v1.2.11...v1.3.0) (2026-06-22)
+
+### Features
+
+* update runtime to nodejs22 [#250](https://github.com/algolia/firestore-algolia-search/pull/250)
+
 ### [1.2.11](https://github.com/algolia/firestore-algolia-search/compare/v1.2.8...v1.2.11) (2026-03-24)
 
 

--- a/extension.yaml
+++ b/extension.yaml
@@ -5,7 +5,7 @@
 name: firestore-algolia-search
 
 # Follow semver versioning
-version: 1.2.11
+version: 1.3.0
 
 # Version of the Firebase Extensions specification
 specVersion: v1beta

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "firestore-algolia-search",
-  "version": "1.2.11",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "firestore-algolia-search",
-      "version": "1.2.11",
+      "version": "1.3.0",
       "dependencies": {
         "@algolia/client-common": "^4.23.3",
         "@algolia/transporter": "^4.23.3",

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firestore-algolia-search",
-  "version": "1.2.11",
+  "version": "1.3.0",
   "description": "Index Cloud Firestore collection to Algolia",
   "scripts": {
     "build": "npm run clean && npm test && npm run compile",

--- a/functions/src/version.ts
+++ b/functions/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '1.2.11';
+export const version = '1.3.0';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "firestore-algolia-search",
-  "version": "1.2.11",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "firestore-algolia-search",
-      "version": "1.2.11",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@commitlint/cli": "^16.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firestore-algolia-search",
-  "version": "1.2.11",
+  "version": "1.3.0",
   "description": "",
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
## Release v1.3.0

Bumps version to 1.3.0 after the Node 22 runtime upgrade (PR #250).

### Changes
- Version bump across all tracked files (package.json, extension.yaml, functions/package.json, functions/src/version.ts, lock files)
- CHANGELOG.md updated

### What's in this release
- Cloud Functions runtime upgraded from nodejs20 to nodejs22
- Deploy-time prepare script fixed to skip tests (prevents TS2306 failure in Firebase Cloud Build sandbox)

This is a release-only PR — no source code changes beyond version bumps.